### PR TITLE
Added Regex support for multi-region for Cognito Userpool

### DIFF
--- a/src/lambda-edge/shared/shared.ts
+++ b/src/lambda-edge/shared/shared.ts
@@ -41,7 +41,7 @@ export function getConfig(): Config {
     const config = JSON.parse(readFileSync(`${__dirname}/configuration.json`).toString('utf8')) as ConfigFromDisk;
 
     // Derive the issuer and JWKS uri all JWT's will be signed with from the User Pool's ID and region:
-    const userPoolRegion = config.userPoolId.match(/(\S{1,3}-\S{1,15}-\S{1,3})_\S*/)![1];
+    const userPoolRegion = config.userPoolId.match(/^(\S+?)_\S+$/)![1];
     const tokenIssuer = `https://cognito-idp.${userPoolRegion}.amazonaws.com/${config.userPoolId}`;
     const tokenJwksUri = `${tokenIssuer}/.well-known/jwks.json`;
 

--- a/src/lambda-edge/shared/shared.ts
+++ b/src/lambda-edge/shared/shared.ts
@@ -41,7 +41,7 @@ export function getConfig(): Config {
     const config = JSON.parse(readFileSync(`${__dirname}/configuration.json`).toString('utf8')) as ConfigFromDisk;
 
     // Derive the issuer and JWKS uri all JWT's will be signed with from the User Pool's ID and region:
-    const userPoolRegion = config.userPoolId.match(/(\S{2}-\S{4}-\S{1,2})_\S*/)![1];
+    const userPoolRegion = config.userPoolId.match(/(\S{1,3}-\S{1,15}-\S{1,3})_\S*/)![1];
     const tokenIssuer = `https://cognito-idp.${userPoolRegion}.amazonaws.com/${config.userPoolId}`;
     const tokenJwksUri = `${tokenIssuer}/.well-known/jwks.json`;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes regex so it supports multi-region Cognito Userpools. Still does not support GOV regions (and it probably doesn't need to either).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
