### PR TITLE
fix: don't use custom error document for 403

### DIFF
--- a/src/lambda-edge/parse-auth/index.ts
+++ b/src/lambda-edge/parse-auth/index.ts
@@ -50,7 +50,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
     } catch (err) {
         return {
             body: createErrorHtml('Bad Request', err.toString(), redirectedFromUri),
-            status: '400', // Note: do not send 403 (!) as we have CloudFront send back index.html for 403's to enable SPA-routing
+            status: '400',
             headers: {
                 ...cloudFrontHeaders,
                 'content-type': [{

--- a/src/lambda-edge/refresh-auth/index.ts
+++ b/src/lambda-edge/refresh-auth/index.ts
@@ -48,7 +48,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
     } catch (err) {
         return {
             body: createErrorHtml('Bad Request', err.toString(), redirectedFromUri),
-            status: '400', // Note: do not send 403 (!) as we have CloudFront send back index.html for 403's to enable SPA-routing 
+            status: '400',
             headers: {
                 ...cloudFrontHeaders,
                 'content-type': [{

--- a/src/lambda-edge/sign-out/index.ts
+++ b/src/lambda-edge/sign-out/index.ts
@@ -15,7 +15,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
     if (!idToken) {
         return {
             body: 'Bad Request',
-            status: '400', // Note: do not send 403 (!) as we have CloudFront send back index.html for 403's to enable SPA-routing
+            status: '400',
             statusDescription: 'Bad Request',
             headers: cloudFrontHeaders,
         };

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
-    SemanticVersion: 1.0.5
+    SemanticVersion: 1.0.6
     SourceCodeUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
 
 Parameters:
@@ -212,6 +212,7 @@ Resources:
           TargetOriginId: protected-bucket
           ViewerProtocolPolicy: redirect-to-https
         Enabled: true
+        DefaultRootObject: index.html
         Origins:
           - DomainName: !Sub "${S3Bucket}.s3.amazonaws.com"
             Id: protected-bucket
@@ -223,9 +224,6 @@ Resources:
             CustomOriginConfig:
               OriginProtocolPolicy: match-viewer
         CustomErrorResponses:
-          - ErrorCode: 403
-            ResponseCode: 200
-            ResponsePagePath: /index.html
           - ErrorCode: 404
             ResponseCode: 200
             ResponsePagePath: /index.html
@@ -249,6 +247,12 @@ Resources:
               - "s3:GetObject"
             Effect: "Allow"
             Resource: !Join ["/", [!GetAtt S3Bucket.Arn, "*"]]
+            Principal:
+              CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+          - Action:
+              - "s3:ListBucket"
+            Effect: "Allow"
+            Resource: !GetAtt S3Bucket.Arn
             Principal:
               CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
 


### PR DESCRIPTION
fix: don't use custom error document for 403 as this exposes index.html on POST requests

*Issue #, if available:*

#25 

*Description of changes:*

- Use DefaultRootObject
- Add s3:ListBucket to bucket policy
- Return 403 from Lambda (this is safe now)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
