### PR TITLE
Add support for multiple identity providers

### DIFF
--- a/src/lambda-edge/parse-auth/index.ts
+++ b/src/lambda-edge/parse-auth/index.ts
@@ -17,7 +17,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
         if (!code || !state || typeof code !== 'string' || typeof state !== 'string') {
             throw new Error('Invalid query string. Your query string should include parameters "state" and "code"');
         }
-        const { nonce: currentNonce, requestedUri } = JSON.parse(state);
+        const { nonce: currentNonce, requestedUri } = JSON.parse(Buffer.from(state, 'base64').toString()); 
         redirectedFromUri += requestedUri || '';
         const { nonce: originalNonce, pkce } = extractAndParseCookies(request.headers, clientId);
         if (!currentNonce || !originalNonce || currentNonce !== originalNonce) {


### PR DESCRIPTION
This is a rather crude hack around a bug in Cognito. Base64Url encode/decode the state variable to enable multiple identity providers.

*Issue #, if available:*

#21 

*Description of changes:*

This is a rather primitive implementation of base64UrlEncode/Decode to get around the Cognito hosted UI error which is preventing this from being used with multiple identity providers. Instead of passing the `state` parameter as a string of JSON, this encodes the string it to base64, then replaces characters that would be encoded in the URL into characters that won't get modified in transit by Cognito.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
