### PR TITLE
Fix base64 encoding

### DIFF
--- a/src/lambda-edge/parse-auth/index.ts
+++ b/src/lambda-edge/parse-auth/index.ts
@@ -13,7 +13,10 @@ export const handler: CloudFrontRequestHandler = async (event) => {
     let redirectedFromUri = `https://${domainName}`;
     
     try {
-        const { code, state } = parseQueryString(request.querystring);
+        const { code, state, error: cognitoError, error_description } = parseQueryString(request.querystring);
+        if (cognitoError) {
+            throw new Error(`[Cognito] ${[cognitoError, error_description].join(': ')}`);
+        }
         if (!code || !state || typeof code !== 'string' || typeof state !== 'string') {
             throw new Error('Invalid query string. Your query string should include parameters "state" and "code"');
         }

--- a/src/lambda-edge/shared/shared.ts
+++ b/src/lambda-edge/shared/shared.ts
@@ -216,7 +216,7 @@ export async function httpPostWithRetry(url: string, data: any, config: AxiosReq
 }
 
 export function createErrorHtml(title: string, message: string, tryAgainHref: string) {
-  return `<!DOCTYPE html>
+    return `<!DOCTYPE html>
 <html lang="en">
   <head>
       <meta charset="utf-8">
@@ -228,4 +228,21 @@ export function createErrorHtml(title: string, message: string, tryAgainHref: st
       <a href="${tryAgainHref}">Try again</a>
   </body>
 </html>`;
+}
+
+export const urlSafe = {
+    /*
+        Functions to translate base64-encoded strings, so they can be used:
+        - in URL's without needing additional encoding
+        - in OAuth2 PKCE verifier
+
+        stringify:
+            use this on a base64-encoded string to translate = + / into replacement characters
+
+        parse:
+            use this on a string that was previously urlSafe.stringify'ed to return it to
+            its prior pure-base64 form. Note that trailing = are not added, but NodeJS does not care
+    */
+    stringify: (b64encodedString: string) => b64encodedString.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_'),
+    parse: (b64encodedString: string) => b64encodedString.replace(/-/g, '+').replace(/_/g, '/'),
 }

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
-    SemanticVersion: 1.0.8
+    SemanticVersion: 1.0.9
     SourceCodeUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
 
 Parameters:

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
-    SemanticVersion: 1.0.9
+    SemanticVersion: 1.0.10
     SourceCodeUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
 
 Parameters:


### PR DESCRIPTION
*Issue #, if available:* #38 

*Description of changes:*
When sending state to Cognito in the URL, do not send chars = / + because Cognito will (incorrectly) decode them for you on the way back. That invalidates the state param, making it impossible to properly decode it.

This fix translates the state param when sent to Cognito to work around the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
