### PR TITLE
Enhance `reuse-auth-only` scenario and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ Providing an email address (as above in step 6) is optional. If you provide it, 
 
 See [./example-serverless-app-reuse](./example-serverless-app-reuse)
 
+### Option 4: Deploy as is, then test a custom application
+You may want to see how your existing application works with the authentication framework before investing the effort to integrate or automate.  One approach involves creating a full deploy from one of the deploy options above, then dropping your application into the bucket that's created.  There are a few points to be aware of:
+
+- If you want your application to load by default instead of the sample REACT single page app (SPA), you'll need to rename the sample REACT's `index.html` and ensure your SPA entry page is named `index.html`.  The renamed sample REACT's page will still work when specifically addressed in a URL.
+- It's also fine to let your SPA have its own page name, but you'll need to remember to test with its actual URL, e.g. if you drop your SPA entry page into the bucket as `myapp.html` your test URL will look like `https://SOMECLOUDFRONTURLSTRING.cloudfront.net/myapp.html`
+- Make sure none of your SPA filenames collide with the REACT app.  Alternately just remove the REACT app first -- but sometimes it's nice to keep it in place to validate that authentication is generally working.
+
+You may find that your application does not render properly -- the default Content Security Policy (CSP) in the CloudFormation parameter may be the issue.  As a quick test you can either remove the `"Content-Security-Policy":"..."` parameter from the CloudFormation's HttpHeaders parameter, or substitute your own. Leave the other headers in the parameter alone unless you have a good reason. 
+
 ## I already have a CloudFront distribution, I just want to add auth
 
 Deploy the solution (e.g. from the [Serverless Application Repository](https://console.aws.amazon.com/lambda/home#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge)) while setting parameter `CreateCloudFrontDistribution` to `false`. This way, only the Lambda@Edge functions will de deployed in your account, including a User Pool and Client. Then you can wire those Lambda@Edge functions up into your own CloudFront distribution. Create a behavior for all path patterns (root, RedirectPathSignIn, RedirectPathSignOut, RedirectPathAuthRefresh, SignOutUrl) and configure the corresponding Lambda@Edge function in each behavior.

--- a/example-serverless-app-reuse/README.md
+++ b/example-serverless-app-reuse/README.md
@@ -2,9 +2,17 @@
 
 This directory contains two examples:
 
-- [reuse-complete.yaml](./reuse-complete.yaml): This examples shows how you can add some users of your own to the serverless application's User Pool. Also it shows how you can access outputs from the serverless application.
+## [reuse-complete.yaml](./reuse-complete.yaml)
+This examples shows how you can add some users of your own to the serverless application's User Pool. Also it shows how you can access outputs from the serverless application.
 
-- [reuse-auth-only.yaml](./reuse-auth-only.yaml): This example shows how you can wire up this solution's auth functions into your own CloudFront distribution. Note the instructions on updating the User Pool client in this example's description.
+## [reuse-auth-only.yaml](./reuse-auth-only.yaml)
+This example shows how to wire up this solution's auth functions into your own CloudFront distribution. Features include:
+
+- An example private S3 bucket resource and parameter to name it
+- An example functional CloudFront distribution providing access to the bucket by Origin Access Identity
+- The nested reused serverless application stack resource illustrating how to pass your  template's parameters to the application, in this case to modify http headers
+- An example showing how to retrieve output parameters from the nested application stack for use in the outer template
+- Note the instructions on updating the User Pool client in this example's description.
 
 ## Deployment
 
@@ -21,3 +29,4 @@ sam deploy --template-file $TEMPLATE --stack-name $STACK_NAME \
 
 ```
 
+or simply launch the sample template in CloudFormatino

--- a/example-serverless-app-reuse/README.md
+++ b/example-serverless-app-reuse/README.md
@@ -12,6 +12,7 @@ This example shows how to wire up this solution's auth functions into your own C
 - An example functional CloudFront distribution providing access to the bucket by Origin Access Identity
 - The nested reused serverless application stack resource illustrating how to pass your  template's parameters to the application, in this case to modify http headers
 - An example showing how to retrieve output parameters from the nested application stack for use in the outer template
+- Parameterized semantic version to allow operation with future versions of the application
 - Note the instructions on updating the User Pool client in this example's description.
 
 ## Deployment
@@ -29,4 +30,4 @@ sam deploy --template-file $TEMPLATE --stack-name $STACK_NAME \
 
 ```
 
-or simply launch the sample template in CloudFormatino
+or simply launch the sample template in CloudFormation

--- a/example-serverless-app-reuse/reuse-auth-only.yaml
+++ b/example-serverless-app-reuse/reuse-auth-only.yaml
@@ -4,15 +4,67 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example stack that shows how to reuse only the auth portion of the serverless application
-  in your own CloudFront distribution. Note that after deployment, you should manually update the
-  User Pool client, and point the Callback URL and Sign out URL at the CloudFront distribution. To work
-  around this circular dependency, you can also add an alternate domain name to the CloudFront distribution,
-  and provide that as parameter to the serverless stack. Then the User Pool client will be set to the right
-  Callback URL and Sign out URL automatically.
+  Example stack to that reuses the auth portion of the serverless application
+  in your own CloudFront distribution. 
+
+  After deployment, manually update the User Pool client to point the 'Callback URL' and 'Sign out URL' to the 
+  URL of the CloudFront distribution. 
+  
+  Alternately, add an alternate domain name to the CloudFront distribution and provide the name as parameter to the 
+  serverless stack. The alternate domain will also require adding a certificate to the Cloudfront Distribution.  
+  This alternative will set  the User Pool client to the right Callback URL and Sign out URL automatically.
+
+  The sample CloudFront distribution illustrates a full pattern of use -- modify it as needed.
+
+  The HttpHeaders parameter and corresponding reference in the 'LambdaEdgeProtection' nested application Resource
+  illustrates how to pass information to the underlying SAM app
+
+  Outputs illustrate retrieving values from the underlying SAM application
+
+Parameters: 
+  BucketNameParameter: 
+    Type: String
+    Description: A legal bucket name.  Must not exist.
+
+  HttpHeaders:
+    Type: String
+    Description: The HTTP headers to set on all responses from CloudFront. To be provided as a JSON object
+    Default: >-
+      {
+        "Content-Security-Policy": "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "Referrer-Policy": "same-origin",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Frame-Options": "DENY",
+        "X-Content-Type-Options": "nosniff"
+      }
 
 Resources:
-
+  ApplicationBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: 
+        Ref: BucketNameParameter
+  CloudFrontOriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: !Sub '${BucketNameParameter}-OAI'
+  S3AccessPolicyForOAI:
+    Type: AWS::S3::BucketPolicy
+    Properties: 
+      Bucket:
+        Ref: ApplicationBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              CanonicalUser:
+                Fn::GetAtt: [ CloudFrontOriginAccessIdentity , S3CanonicalUserId ]
+            Action: "s3:GetObject"
+            Resource: !Sub "${ApplicationBucket.Arn}/*"
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -64,10 +116,19 @@ Resources:
             Id: dummy-origin
             CustomOriginConfig:
               OriginProtocolPolicy: match-viewer
-          - DomainName: change.this.to.your.origin
+          - DomainName: !Sub "${ApplicationBucket}.s3.amazonaws.com"
             Id: protected-origin
-            CustomOriginConfig:
-              OriginProtocolPolicy: match-viewer
+            S3OriginConfig:
+              OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
+        CustomErrorResponses:
+            - ErrorCode: 404
+              ResponseCode: 200
+              ResponsePagePath: /index.html
+            - ErrorCode: 403
+              ResponseCode: 200
+              ResponsePagePath: /index.html
+        PriceClass: PriceClass_100
+        DefaultRootObject: index.html
 
   LambdaEdgeProtection:
     Type: AWS::Serverless::Application
@@ -77,4 +138,9 @@ Resources:
         SemanticVersion: 1.1.0
       Parameters:
         CreateCloudFrontDistribution: "false"
+        HttpHeaders: !Ref HttpHeaders
         # AlternateDomainNames: <your alternate domain names, this will be the same list as the aliases of your CloudFront distribution above>
+Outputs:
+  UserPoolId:
+    Description: The user pool id to illustrate how to retrieve outputs from the SAM app
+    Value: !GetAtt LambdaEdgeProtection.Outputs.UserPoolId

--- a/example-serverless-app-reuse/reuse-auth-only.yaml
+++ b/example-serverless-app-reuse/reuse-auth-only.yaml
@@ -34,7 +34,7 @@ Parameters:
   SemanticVersion:
     Type: String
     Description: Semantic version of the back end
-    Default: 1.1.0
+    Default: 1.1.1
 
   HttpHeaders:
     Type: String
@@ -132,9 +132,6 @@ Resources:
               OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}"
         CustomErrorResponses:
             - ErrorCode: 404
-              ResponseCode: 200
-              ResponsePagePath: /index.html
-            - ErrorCode: 403
               ResponseCode: 200
               ResponsePagePath: /index.html
         PriceClass: !Ref PriceClass

--- a/example-serverless-app-reuse/reuse-auth-only.yaml
+++ b/example-serverless-app-reuse/reuse-auth-only.yaml
@@ -26,12 +26,22 @@ Parameters:
     Type: String
     Description: A legal bucket name.  Must not exist.
 
+  PriceClass:
+    Type: String
+    Description: CloudFront price class, e.g. PriceClass_200 for most regions (default), PriceClass_All for all regions (the default), PriceClass_100 least expensive (US, Canada, Europe), or PriceClass_All
+    Default: PriceClass_200
+
+  SemanticVersion:
+    Type: String
+    Description: Semantic version of the back end
+    Default: 1.1.0
+
   HttpHeaders:
     Type: String
-    Description: The HTTP headers to set on all responses from CloudFront. To be provided as a JSON object
+    Description: The HTTP headers to set on all responses from CloudFront. Defaults are illustrations only and contain a report-only Cloud Security Policy -- adjust for your application
     Default: >-
       {
-        "Content-Security-Policy": "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com",
+        "Content-Security-Policy-Report-Only": "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com",
         "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
         "Referrer-Policy": "same-origin",
         "X-XSS-Protection": "1; mode=block",
@@ -127,7 +137,7 @@ Resources:
             - ErrorCode: 403
               ResponseCode: 200
               ResponsePagePath: /index.html
-        PriceClass: PriceClass_100
+        PriceClass: !Ref PriceClass
         DefaultRootObject: index.html
 
   LambdaEdgeProtection:
@@ -135,7 +145,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
-        SemanticVersion: 1.1.0
+        SemanticVersion: !Ref SemanticVersion
       Parameters:
         CreateCloudFrontDistribution: "false"
         HttpHeaders: !Ref HttpHeaders


### PR DESCRIPTION
*Issue #, if available:* #24 

*Description of changes:*

1. Enhance `reuse-auth-only.yaml` example 
- Enable naming S3 bucket so example can be used as a basis for an actual deploy
- Enhance CloudFront distribution with OAI and other features for a complete SPA site deploy
- Provide additional examples of parameter passing to and from nested application stack
- Flesh out documentation
2. Enhance main README to detail how to test own SPA application in the full template deploy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
