### PR TITLE
npm install fails on [[ ]] conditionals on Ubuntu

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "webpack": "webpack --progress",
     "analyze": "webpack --profile --json > stats.json && webpack-bundle-analyzer ./stats.json",
     "build": "npm run tsc && npm run webpack",
-    "update-dependencies": "for DIR in . $(ls -d src/cfn-custom-resources/*) $(ls -d src/lambda-edge/*); do [[ ! -f ${DIR}/package.json ]] || (cd ${DIR} && echo \"Updating ${DIR} ...\" && rm -rf node_modules package-lock.json && npm update --dev); done; npm i",
-    "postinstall": "for DIR in $(ls -d src/cfn-custom-resources/*) $(ls -d src/lambda-edge/*); do [[ ! -f ${DIR}/package.json ]] || (cd ${DIR} && echo \"Updating ${DIR} ...\" && npm install --ignore-scripts); done"
+    "update-dependencies": "for DIR in . $(ls -d src/cfn-custom-resources/*) $(ls -d src/lambda-edge/*); do [ ! -f ${DIR}/package.json ] || (cd ${DIR} && echo \"Updating ${DIR} ...\" && rm -rf node_modules package-lock.json && npm update --dev); done; npm i",
+    "postinstall": "for DIR in $(ls -d src/cfn-custom-resources/*) $(ls -d src/lambda-edge/*); do [ ! -f ${DIR}/package.json ] || (cd ${DIR} && echo \"Updating ${DIR} ...\" && npm install --ignore-scripts); done"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This is because on Ubuntu 18, `/bin/sh` is Dash shell. Dash does not support the fancy `[[ ]]` style conditionals in the scripts section of `package.json`.

*Description of changes:*

I changed these to `[ ]` style conditionals, which work just as well for any shell here, including Dash.

The rest of the workflow works fine on Ubuntu 18.04. Thanks for the nice code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
