### PR TITLE
Output the ARN of the User Pool Client Update Handler, and only expor…

### DIFF
--- a/example-serverless-app-reuse/reuse-auth-only.yaml
+++ b/example-serverless-app-reuse/reuse-auth-only.yaml
@@ -32,7 +32,7 @@ Parameters:
   SemanticVersion:
     Type: String
     Description: Semantic version of the back end
-    Default: 2.0.0
+    Default: 2.0.1
 
   HttpHeaders:
     Type: String

--- a/example-serverless-app-reuse/reuse-complete.yaml
+++ b/example-serverless-app-reuse/reuse-complete.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
-        SemanticVersion: 2.0.0
+        SemanticVersion: 2.0.1
   AlanTuring:
     Type: AWS::Cognito::UserPoolUser
     Properties:

--- a/example-serverless-app-reuse/reuse-with-existing-user-pool.yaml
+++ b/example-serverless-app-reuse/reuse-with-existing-user-pool.yaml
@@ -64,7 +64,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
-        SemanticVersion: 2.0.0
+        SemanticVersion: 2.0.1
       Parameters:
         UserPoolArn: !GetAtt UserPool.Arn
         UserPoolClientId: !Ref UserPoolClient

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
-    SemanticVersion: 2.0.0
+    SemanticVersion: 2.0.1
     SourceCodeUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
 
 Parameters:
@@ -146,6 +146,9 @@ Conditions:
     - !Equals [!Ref EnableSPAMode, "true"]
     - !Equals [!Ref CreateCloudFrontDistribution, "true"]
   CreateUserPoolAndClient: !Equals [!Ref UserPoolArn, ""]
+  UpdateUserPoolClient: !Or
+    - !Equals [!Ref CreateCloudFrontDistribution, "true"]
+    - !Not [!Equals [!Join ["", !Ref AlternateDomainNames], ""]]
 
 Globals:
   Function:
@@ -389,6 +392,7 @@ Resources:
 
   UserPoolClientUpdate:
     Type: Custom::UserPoolClientUpdate
+    Condition: UpdateUserPoolClient
     Properties:
       ServiceToken: !GetAtt UserPoolClientUpdateHandler.Arn
       UserPoolArn: !If
@@ -826,11 +830,13 @@ Outputs:
       Name: !Sub "${AWS::StackName}-CognitoAuthDomain"
   RedirectUrisSignIn:
     Description: The URI(s) that will handle the redirect from Cognito after successfull sign-in
+    Condition: UpdateUserPoolClient
     Value: !GetAtt UserPoolClientUpdate.RedirectUrisSignIn
     Export:
       Name: !Sub "${AWS::StackName}-RedirectUrisSignIn"
   RedirectUrisSignOut:
     Description: The URI(s) that will handle the redirect from Cognito after successfull sign-out
+    Condition: UpdateUserPoolClient
     Value: !GetAtt UserPoolClientUpdate.RedirectUrisSignOut
     Export:
       Name: !Sub "${AWS::StackName}-RedirectUrisSignOut"
@@ -864,3 +870,8 @@ Outputs:
     Value: !GetAtt LambdaCodeUpdateHandler.Arn
     Export:
       Name: !Sub "${AWS::StackName}-CodeUpdateHandler"
+  UserPoolClientUpdateHandler:
+    Description: The Lambda function ARN of the custom resource that updates the user pool client with the right redirect URI's for sign-in and sign-out
+    Value: !GetAtt UserPoolClientUpdateHandler.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-UserPoolClientUpdateHandler"


### PR DESCRIPTION
…t the redirect URI's if they were set in the first place

*Issue #, if available:* #82 

*Description of changes:*

- Output the ARN of the User Pool Client Update Handler. This makes it possible to reuse this piece of code, in a higher level stack (i.e. when using Auth@Edge as a nested stack).
- Do not export the redirect URI's if they were not set in the first place, as that leads to an error in CloudFormation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
