### PR TITLE
optional required group parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ You can use a pre-existing Cognito User Pool (e.g. from another region), by prov
 
 In this case, also specify a pre-existing User Pool Client ID. Note that the solution's callback URLs wil be added to the User Pool Client you provide.
 
+## I want to use a social identity provider
+
+You should use the UserPoolGroupName parameter, to specify a group that users must be a member of in order to access the site.
+
+Without this UserPoolGroupName, the lambda@edge functions will allow any confirmed user in the User Pool access to the site.
+When an identity provider is added to the User Pool, anybody that signs in though the identity provider is immediately a confirmed user.
+So with a social identity provider where anyone can create an account, this means anyone can access the site you are trying to protect.
+
+With the UserPoolGroupName parameter defined, you will need to add each user to this group before they can access the site.
+
+If the solution is creating the User Pool, it will create the User Pool Group too.
+If the solution is creating the User Pool and a default user (via the EmailAddress parameter), then this user will be added User Pool Group.
+
+If you are using a pre-existing User Pool, you will need to make a group that has a name matching the UserPoolGroupName.
+
 ## Deployment region
 
 This solution contains CloudFront and Lambda@Edge resources that must be deployed to us-east-1 (but will run in all [Points of Presence](https://aws.amazon.com/cloudfront/features/#Amazon_CloudFront_Infrastructure) globally).

--- a/src/lambda-edge/shared/shared.ts
+++ b/src/lambda-edge/shared/shared.ts
@@ -460,15 +460,19 @@ export async function validateAndCheckIdToken(idToken: string, config: CompleteC
     let idTokenPayload = await validate(idToken, config.tokenJwksUri, config.tokenIssuer, config.clientId);
     config.logger.info('JWT is valid');
 
+    if (idTokenPayload == undefined) {
+      throw new Error('Token payload is undefined');
+    }
+
     // Check that the ID token has the required group.
     if (config.requiredGroup) {
         let cognitoGroups = idTokenPayload['cognito:groups'];
         if (!cognitoGroups) {
-            throw new MissingRequiredGroupError('Token does not have any cognito groups');
+            throw new MissingRequiredGroupError('Token does not have any groups');
         }
 
         if (!cognitoGroups.includes(config.requiredGroup)) {
-            throw new MissingRequiredGroupError('Token does not have requiredGroup');
+            throw new MissingRequiredGroupError('Token does not have required group');
         }
         config.logger.info('JWT has requiredGroup');
     }

--- a/src/lambda-edge/shared/validate-jwt.ts
+++ b/src/lambda-edge/shared/validate-jwt.ts
@@ -42,9 +42,9 @@ export async function validate(jwtToken: string, jwksUri: string, issuer: string
         issuer,
         ignoreExpiration: false,
     };
-    return new Promise((resolve, reject) => verify(
+    return new Promise<any>((resolve, reject) => verify(
         jwtToken,
         jwk,
         verificationOptions,
-        (err) => err ? reject(err) : resolve()));
+        (err, decoded) => err ? reject(err) : resolve(decoded)));
 }

--- a/src/lambda-edge/shared/validate-jwt.ts
+++ b/src/lambda-edge/shared/validate-jwt.ts
@@ -42,7 +42,13 @@ export async function validate(jwtToken: string, jwksUri: string, issuer: string
         issuer,
         ignoreExpiration: false,
     };
-    return new Promise<any>((resolve, reject) => verify(
+
+    // The types in jsonwebtoken indicate that the type of `decoded` passed to the callback
+    // is `object | undefined`, however a type of object makes it hard to look up claims.
+    // decoded['something'] is not allowed by typescript
+    // The jsonwebtoken decode function returns a type of { [key: string]: any }
+    // so that is what is used here to make it more convenient
+    return new Promise<{ [key: string]: any } | undefined>((resolve, reject) => verify(
         jwtToken,
         jwk,
         verificationOptions,

--- a/template.yaml
+++ b/template.yaml
@@ -115,9 +115,12 @@ Parameters:
     Type: String
     Description: "Specify the ID of an existing user pool client to use that one instead of creating a new one. If specified, then UserPoolArn must also be specified. Note: new callback URL's will be added to the pre-existing user pool client"
     Default: ""
-  UserPoolRequiredGroup:
+  UserPoolGroupName:
     Type: String
-    Description: "Specify a group that a user has to be part of to view private site. If left blank any user in the pool can access the private site. You will need to manually create this group."
+    Description: >
+      Specify a group that a user has to be part of to view the private site. If left blank, any user in the pool can access the private site.
+      The UserPoolGroup will be created if the UserPool also created (that happens when no UserPoolArn is set).
+      If the group is created and the default user is created, the default user will also be added to the group.
     Default: ""
   Version:
     Type: String
@@ -150,6 +153,12 @@ Conditions:
     - !Equals [!Ref EnableSPAMode, "true"]
     - !Equals [!Ref CreateCloudFrontDistribution, "true"]
   CreateUserPoolAndClient: !Equals [!Ref UserPoolArn, ""]
+  CreateUserPoolGroup: !And
+    - !Condition CreateUserPoolAndClient
+    - !Not [!Equals [!Ref UserPoolGroupName, ""]]
+  AttachUserToPoolGroup: !And
+    - !Condition CreateUser
+    - !Condition CreateUserPoolGroup
   UpdateUserPoolClient: !Or
     - !Equals [!Ref CreateCloudFrontDistribution, "true"]
     - !Not [!Equals [!Join ["", !Ref AlternateDomainNames], ""]]
@@ -327,10 +336,25 @@ Resources:
       UsernameAttributes:
         - email
 
+  UserPoolGroup:
+    Type: AWS::Cognito::UserPoolGroup
+    Condition: CreateUserPoolGroup
+    Properties:
+      GroupName: !Ref UserPoolGroupName
+      UserPoolId: !Ref UserPool
+
   User:
     Type: AWS::Cognito::UserPoolUser
     Condition: CreateUser
     Properties:
+      Username: !Ref EmailAddress
+      UserPoolId: !Ref UserPool
+
+  UserPoolGroupAttachment:
+    Type: AWS::Cognito::UserPoolUserToGroupAttachment
+    Condition: AttachUserToPoolGroup
+    Properties:
+      GroupName: !Ref UserPoolGroupName
       Username: !Ref EmailAddress
       UserPoolId: !Ref UserPool
 
@@ -567,7 +591,7 @@ Resources:
               "nonceSigningSecret": "${NonceSigningSecret}",
               "cookieCompatibility": "${CookieCompatibility}",
               "additionalCookies": ${AdditionalCookies},
-              "requiredGroup": "${UserPoolRequiredGroup}"
+              "requiredGroup": "${UserPoolGroupName}"
             }
           - Mode: !If
               - SPAMode
@@ -618,7 +642,7 @@ Resources:
               "nonceSigningSecret": "${NonceSigningSecret}",
               "cookieCompatibility": "${CookieCompatibility}",
               "additionalCookies": ${AdditionalCookies},
-              "requiredGroup": "${UserPoolRequiredGroup}"
+              "requiredGroup": "${UserPoolGroupName}"
             }
           - Mode: !If
               - SPAMode
@@ -682,7 +706,7 @@ Resources:
               "nonceSigningSecret": "${NonceSigningSecret}",
               "cookieCompatibility": "${CookieCompatibility}",
               "additionalCookies": ${AdditionalCookies},
-              "requiredGroup": "${UserPoolRequiredGroup}"
+              "requiredGroup": "${UserPoolGroupName}"
             }
           - Mode: !If
               - SPAMode
@@ -733,7 +757,7 @@ Resources:
               "nonceSigningSecret": "${NonceSigningSecret}",
               "cookieCompatibility": "${CookieCompatibility}",
               "additionalCookies": ${AdditionalCookies},
-              "requiredGroup": "${UserPoolRequiredGroup}"
+              "requiredGroup": "${UserPoolGroupName}"
             }
           - Mode: !If
               - SPAMode

--- a/template.yaml
+++ b/template.yaml
@@ -115,6 +115,10 @@ Parameters:
     Type: String
     Description: "Specify the ID of an existing user pool client to use that one instead of creating a new one. If specified, then UserPoolArn must also be specified. Note: new callback URL's will be added to the pre-existing user pool client"
     Default: ""
+  UserPoolRequiredGroup:
+    Type: String
+    Description: "Specify a group that a user has to be part of to view private site. If left blank any user in the pool can access the private site. You will need to manually create this group."
+    Default: ""
   Version:
     Type: String
     Description: "Use for development: putting in a new version forces redeployment of Lambda@Edge functions"
@@ -562,7 +566,8 @@ Resources:
               "logLevel": "${LogLevel}",
               "nonceSigningSecret": "${NonceSigningSecret}",
               "cookieCompatibility": "${CookieCompatibility}",
-              "additionalCookies": ${AdditionalCookies}
+              "additionalCookies": ${AdditionalCookies},
+              "requiredGroup": "${UserPoolRequiredGroup}"
             }
           - Mode: !If
               - SPAMode
@@ -612,7 +617,8 @@ Resources:
               "logLevel": "${LogLevel}",
               "nonceSigningSecret": "${NonceSigningSecret}",
               "cookieCompatibility": "${CookieCompatibility}",
-              "additionalCookies": ${AdditionalCookies}
+              "additionalCookies": ${AdditionalCookies},
+              "requiredGroup": "${UserPoolRequiredGroup}"
             }
           - Mode: !If
               - SPAMode
@@ -675,7 +681,8 @@ Resources:
               "logLevel": "${LogLevel}",
               "nonceSigningSecret": "${NonceSigningSecret}",
               "cookieCompatibility": "${CookieCompatibility}",
-              "additionalCookies": ${AdditionalCookies}
+              "additionalCookies": ${AdditionalCookies},
+              "requiredGroup": "${UserPoolRequiredGroup}"
             }
           - Mode: !If
               - SPAMode
@@ -725,7 +732,8 @@ Resources:
               "logLevel": "${LogLevel}",
               "nonceSigningSecret": "${NonceSigningSecret}",
               "cookieCompatibility": "${CookieCompatibility}",
-              "additionalCookies": ${AdditionalCookies}
+              "additionalCookies": ${AdditionalCookies},
+              "requiredGroup": "${UserPoolRequiredGroup}"
             }
           - Mode: !If
               - SPAMode


### PR DESCRIPTION
*Issue #, if available:*
#53 

*Description of changes:*
When a federated social IdP is added to the user pool of this solution, Cogito will issue tokens for any
user of that IdP.  This means the solution is no longer protecting the private files.  
This PR provides a fix for this by adding new SAM parameter `UserPoolRequiredGroup`. This parameter is optional, if it is not provided the code should continue to work the same way.<sup>[1](#f1)</sup>  

If this parameter is set then the idToken from Cognito is checked to see if its 'cognito:groups' claim includes the required group.  This check is done when the tokens are first retrieved from Cognito (parse-auth), as well as on every other request for content in S3 (check-auth).

If the check fails in parse-auth then the user is shown an error page asking them to contact their admin. 

If the check fails in check-auth, the user is redirected Cognito<sup>[2](#f2)</sup> . Cognito will likely see the user is already logged in and then redirect them to parse-auth.  Finally at parse-auth the user will see the error page asking them to contact their admin. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
<hr>
<b id="f1">1</b> There is one minor change, the id token is now be validated immediately after it is fetched from Cognito in parse-auth. This seems like it can't hurt and might possibly improve security

<b id="f2">2</b> The check-auth function also redirects to Cognito if the token is expired or something else about it is in invalid. This behavior was in place before this PR.
