### PR TITLE
Update undefined values to be explicit

### DIFF
--- a/src/lambda-edge/shared/shared.ts
+++ b/src/lambda-edge/shared/shared.ts
@@ -441,7 +441,7 @@ function _generateCookieHeaders(
     "spa-auth-edge-nonce-hmac",
     "spa-auth-edge-pkce",
   ].forEach((key) => {
-    cookies[key] = expireCookie(cookies[key]);
+    cookies[key] = expireCookie();
   });
 
   // Return cookie object in format of CloudFront headers


### PR DESCRIPTION
The existing function calls were subtly passing along `undefined` values; this update makes it explicit.

(either way, the 3 values are being set to `'; Expires=Thu, 01 Jan 1970 00:00:00 GMT'`)

Fixes: #89
