### PR TITLE
Fix refreshAuth handling null clientSecret

### DIFF
--- a/src/lambda-edge/refresh-auth/index.ts
+++ b/src/lambda-edge/refresh-auth/index.ts
@@ -54,7 +54,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
       "Content-Type": "application/x-www-form-urlencoded",
     };
 
-    if (CONFIG.clientSecret !== "") {
+    if (CONFIG.clientSecret) {
       const encodedSecret = Buffer.from(
         `${CONFIG.clientId}:${CONFIG.clientSecret}`
       ).toString("base64");


### PR DESCRIPTION
null/undefined was causing a bad authorization header to be present when refreshing token.
See clientSecret check here https://github.com/aws-samples/cloudfront-authorization-at-edge/blob/master/src/lambda-edge/parse-auth/index.ts#L62

*Issue #, if available:*

*Description of changes:*
Change clientSecret check to just see if it is present

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
