### PR TITLE
Remove ClientSecret from UpdateClientPool

### DIFF
--- a/src/cfn-custom-resources/user-pool-client/index.ts
+++ b/src/cfn-custom-resources/user-pool-client/index.ts
@@ -73,11 +73,13 @@ async function updateUserPoolClient(
     AllowedOAuthScopes = [];
   }
 
-  // Provide existing fields as well, experience teaches this prevents errors when calling the Cognito API
+  // Provide existing fields as well (excluding properties not valid for Update operations), experience teaches this prevents errors when calling the Cognito API
   // https://github.com/aws-samples/cloudfront-authorization-at-edge/issues/144
+  // https://github.com/aws-samples/cloudfront-authorization-at-edge/issues/172
   const existingFields = { ...existingUserPoolClient };
   delete existingFields.CreationDate;
   delete existingFields.LastModifiedDate;
+  delete existingFields.ClientSecret;
 
   const input: CognitoIdentityServiceProvider.Types.UpdateUserPoolClientRequest =
     {


### PR DESCRIPTION
_Issue #172:_ UpdateClientPool fails with unknown key 'ClientSecret'

_Description of changes:_ Remove ClientSecret from the UpdateClientPool call

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
