### PR TITLE
fix: Append other cookie properties when expiring cookies

### DIFF
--- a/src/lambda-edge/shared/shared.ts
+++ b/src/lambda-edge/shared/shared.ts
@@ -447,7 +447,7 @@ function _generateCookieHeaders(
     "spa-auth-edge-nonce-hmac",
     "spa-auth-edge-pkce",
   ].forEach((key) => {
-    cookies[key] = expireCookie();
+    cookies[key] = expireCookie(`;${param.cookieSettings.nonce}`);
   });
 
   // Return cookie object in format of CloudFront headers


### PR DESCRIPTION
Issue #206 

To expire the _nonce_ cookies, append the same cookie properties that were used when the cookies were originally generated. These are available from `CONFIG.cookieSettings.nonce` and are passed in during the call to `generateCookieHeaders(...)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
