### PR TITLE
Show browser cache explanation in sample React app

### DIFF
--- a/example-serverless-app-reuse/reuse-auth-only.yaml
+++ b/example-serverless-app-reuse/reuse-auth-only.yaml
@@ -32,7 +32,7 @@ Parameters:
   SemanticVersion:
     Type: String
     Description: Semantic version of the back end
-    Default: 2.1.4
+    Default: 2.1.5
 
   HttpHeaders:
     Type: String

--- a/example-serverless-app-reuse/reuse-complete-cdk.ts
+++ b/example-serverless-app-reuse/reuse-complete-cdk.ts
@@ -19,7 +19,7 @@ const authAtEdge = new sam.CfnApplication(stack, "AuthorizationAtEdge", {
   location: {
     applicationId:
       "arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge",
-    semanticVersion: "2.1.4",
+    semanticVersion: "2.1.5",
   },
   parameters: {
     EmailAddress: "johndoe@example.com",

--- a/example-serverless-app-reuse/reuse-complete.yaml
+++ b/example-serverless-app-reuse/reuse-complete.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
-        SemanticVersion: 2.1.4
+        SemanticVersion: 2.1.5
   AlanTuring:
     Type: AWS::Cognito::UserPoolUser
     Properties:

--- a/example-serverless-app-reuse/reuse-with-existing-user-pool.yaml
+++ b/example-serverless-app-reuse/reuse-with-existing-user-pool.yaml
@@ -75,7 +75,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
-        SemanticVersion: 2.1.4
+        SemanticVersion: 2.1.5
       Parameters:
         UserPoolArn: !GetAtt UserPool.Arn
         UserPoolClientId: !Ref UserPoolClient

--- a/src/cfn-custom-resources/react-app/react-app/src/App.css
+++ b/src/cfn-custom-resources/react-app/react-app/src/App.css
@@ -17,6 +17,11 @@
   text-align: center;
 }
 
+.explanation-tight {
+  max-width: 500px;
+  text-align: center;
+}
+
 /* Tooltip container */
 .config {
   position: relative;

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
-    SemanticVersion: 2.1.4
+    SemanticVersion: 2.1.5
     SourceCodeUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
 
 Parameters:
@@ -150,7 +150,7 @@ Parameters:
   Version:
     Type: String
     Description: "Changing this parameter after initial deployment forces redeployment of Lambda@Edge functions"
-    Default: "2.1.4"
+    Default: "2.1.5"
   LogLevel:
     Type: String
     Description: "Use for development: setting to a value other than none turns on logging at that level. Warning! This will log sensitive data, use for development only"


### PR DESCRIPTION
_Issue #, if available:_ N/A

_Description of changes:_ Show browser cache explanation in sample React app. Since v2.1.4 the React app (index.html) may be cached by browsers. This PR adds a little explanation, on what is going on in that case. Because otherwise it might appear that you're downloading content without being authenticated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
