### PR TITLE
add /index.html when uri ending with a word that doesn't contains a dot

### DIFF
--- a/src/lambda-edge/rewrite-trailing-slash/index.ts
+++ b/src/lambda-edge/rewrite-trailing-slash/index.ts
@@ -12,6 +12,8 @@ export const handler: CloudFrontRequestHandler = async (event) => {
   const request = event.Records[0].cf.request;
   if (request.uri.endsWith("/")) {
     request.uri += "index.html";
+  } else if (!request.uri.split("/").pop().includes(".")) {
+    request.uri += "/index.html";
   }
   CONFIG.logger.debug("Returning request:\n", request);
   return request;

--- a/template.yaml
+++ b/template.yaml
@@ -166,7 +166,7 @@ Parameters:
     Type: String
     Default: ""
   RewritePathWithTrailingSlashToIndex:
-    Description: Do you want to append "index.html" to paths that end with a slash ("/")?
+    Description: Do you want to append "index.html" to paths that end with a slash ("/") or a word that doesn't contains a dot (".")?
     Type: String
     Default: "false"
     AllowedValues:
@@ -1256,7 +1256,7 @@ Outputs:
     Export:
       Name: !Sub "${AWS::StackName}-SignOutHandler"
   TrailingSlashHandler:
-    Description: The Lambda function ARN to use in Lambda@Edge for appending index.html to paths ending with a slash ("/")
+    Description: The Lambda function ARN to use in Lambda@Edge for appending index.html to paths ending with a slash ("/") or a word that doesn't contains a dot (".")
     Condition: RewritePathWithTrailingSlashToIndex
     Value: !GetAtt TrailingSlashHandlerCodeUpdate.FunctionArn
     Export:


### PR DESCRIPTION
_Description of changes:_

Whit this change, when `RewritePathWithTrailingSlashToIndex=true` , uris ending in a word that doesn't contains a dot (".") has the same behavior as a uri ending in a slash ("/).

In others words, `http://example.com/path` and `http://example.com/path/` are rewrite as `http://example.com/path/index.html`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
