### PR TITLE
fix: set request timeout to 4s by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/aws-lambda": "^8.10.92",
         "@types/cookie": "^0.4.1",
         "@types/fs-extra": "^9.0.13",
-        "@types/node": "^17.0.14",
+        "@types/node": "^18.15.12",
         "aws-sdk": "^2.1354.0",
         "html-loader": "^3.1.0",
         "prettier": "^2.5.1",
@@ -173,9 +173,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "version": "18.15.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.12.tgz",
+      "integrity": "sha512-Wha1UwsB3CYdqUm2PPzh/1gujGCNtWVUYF0mB00fJFoR4gTyWTDPjSm+zBF787Ahw8vSGgBja90MkgFwvB86Dg==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -2761,9 +2761,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "version": "18.15.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.12.tgz",
+      "integrity": "sha512-Wha1UwsB3CYdqUm2PPzh/1gujGCNtWVUYF0mB00fJFoR4gTyWTDPjSm+zBF787Ahw8vSGgBja90MkgFwvB86Dg==",
       "dev": true
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/aws-lambda": "^8.10.92",
     "@types/cookie": "^0.4.1",
     "@types/fs-extra": "^9.0.13",
-    "@types/node": "^17.0.14",
+    "@types/node": "^18.15.12",
     "aws-sdk": "^2.1354.0",
     "html-loader": "^3.1.0",
     "prettier": "^2.5.1",

--- a/src/lambda-edge/shared/https.ts
+++ b/src/lambda-edge/shared/https.ts
@@ -5,6 +5,8 @@ import { IncomingHttpHeaders } from "http";
 import { request, RequestOptions } from "https";
 import { Writable, pipeline } from "stream";
 
+const DEFAULT_REQUEST_TIMEOUT = 4000; // 4 seconds
+
 export async function fetch(
   uri: string,
   data?: Buffer,
@@ -15,7 +17,12 @@ export async function fetch(
     headers: IncomingHttpHeaders;
     data: Buffer;
   }>((resolve, reject) => {
-    const req = request(uri, options ?? {}, (res) =>
+    const requestOptions = {
+      signal: AbortSignal.timeout(DEFAULT_REQUEST_TIMEOUT),
+      ...(options ?? {}),
+    };
+
+    const req = request(uri, requestOptions, (res) =>
       pipeline(
         [
           res,


### PR DESCRIPTION
_Description of changes:_

Viewer request lambda edge timeout max is 5s which leads to unhandled exceptions when https requests take longer. Setting a default timeout for https request to 4s is a first step in avoiding requests timeout leading to unhandled errors such as:

<img width="1381" alt="image" src="https://user-images.githubusercontent.com/39985796/228808331-10d78c03-97bd-4023-ac0a-e3a804713719.png">

Next step would be to anticipate lambda timeout with `getRemainingTimeInMillis()`  [context method](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html) and set the request timeout to this number minus a few milliseconds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
