### PR TITLE
fix: resolve jQuery vulnerability

### DIFF
--- a/src/lambda-edge/shared/error-page/template.html
+++ b/src/lambda-edge/shared/error-page/template.html
@@ -60,8 +60,8 @@
       </div>
     </div>
     <script
-      src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
+      src="https://code.jquery.com/jquery-3.5.0.slim.min.js"
+      integrity="sha384-/IFzzQmt1S744I+IQO4Mc1uphkxbXt1tEwjQ/qSw2p8pXWck09sLvqHmKDYYwReJ"
       crossorigin="anonymous"
     ></script>
     <script


### PR DESCRIPTION
jQuery versions below 3.5.0 used a regex in its jQuery.htmlPrefilter method. This regex which is used to ensure that all tags are XHTML-compliant could introduce a vulnerability to Cross-site Scripting(XSS) attack.

_Description of changes:_

As stated in the [jQuery release note](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/): 

## Security Fix
The main change in this release is a security fix, and it’s possible you will need to change your own code to adapt. Here’s why: jQuery used a regex in its [jQuery.htmlPrefilter](https://api.jquery.com/jQuery.htmlPrefilter/) method to ensure that all closing tags were XHTML-compliant when passed to methods. For example, this prefilter ensured that a call like jQuery("`<div class='hot' />`") is actually converted to jQuery("`<div class='hot'></div>`"). Recently, an issue was reported that demonstrated the regex could introduce a cross-site scripting (XSS) vulnerability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
