### PR TITLE
Empty us east 1 deployment bucket upon stack delete

### DIFF
--- a/example-serverless-app-reuse/reuse-auth-only.yaml
+++ b/example-serverless-app-reuse/reuse-auth-only.yaml
@@ -32,7 +32,7 @@ Parameters:
   SemanticVersion:
     Type: String
     Description: Semantic version of the back end
-    Default: 2.1.6
+    Default: 2.1.7
 
   HttpHeaders:
     Type: String

--- a/example-serverless-app-reuse/reuse-complete-cdk.ts
+++ b/example-serverless-app-reuse/reuse-complete-cdk.ts
@@ -19,7 +19,7 @@ const authAtEdge = new sam.CfnApplication(stack, "AuthorizationAtEdge", {
   location: {
     applicationId:
       "arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge",
-    semanticVersion: "2.1.6",
+    semanticVersion: "2.1.7",
   },
   parameters: {
     EmailAddress: "johndoe@example.com",

--- a/example-serverless-app-reuse/reuse-complete.yaml
+++ b/example-serverless-app-reuse/reuse-complete.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
-        SemanticVersion: 2.1.6
+        SemanticVersion: 2.1.7
   AlanTuring:
     Type: AWS::Cognito::UserPoolUser
     Properties:

--- a/example-serverless-app-reuse/reuse-with-existing-user-pool.yaml
+++ b/example-serverless-app-reuse/reuse-with-existing-user-pool.yaml
@@ -75,7 +75,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge
-        SemanticVersion: 2.1.6
+        SemanticVersion: 2.1.7
       Parameters:
         UserPoolArn: !GetAtt UserPool.Arn
         UserPoolClientId: !Ref UserPoolClient

--- a/template.yaml
+++ b/template.yaml
@@ -423,6 +423,8 @@ Resources:
                 - s3:PutObject
                 - s3:CreateBucket
                 - s3:DeleteBucket
+                - s3:DeleteObject
+                - s3:ListBucket
               Resource: !Sub "arn:${AWS::Partition}:s3:::*-authedgedeploymentbucket-*"
             - Effect: Allow
               Action: lambda:GetFunction

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
-    SemanticVersion: 2.1.6
+    SemanticVersion: 2.1.7
     SourceCodeUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
 
 Parameters:
@@ -150,7 +150,7 @@ Parameters:
   Version:
     Type: String
     Description: "Changing this parameter after initial deployment forces redeployment of Lambda@Edge functions"
-    Default: "2.1.6"
+    Default: "2.1.7"
   LogLevel:
     Type: String
     Description: "Use for development: setting to a value other than none turns on logging at that level. Warning! This will log sensitive data, use for development only"


### PR DESCRIPTION
_Issue #, if available:_ #242

_Description of changes:_ When the us-east-1 stack is deleted, the S3 bucket in it, that is used for deployments of the Lambda@Edge functions, must first be emptied. This PR implements that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
