### PR TITLE
Feat: Implement Log Groups properties for CloudFrontAuthorization

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -216,7 +216,7 @@ Parameters:
   ResourceSuffix:
     Description: The lambda suffix to use, will be common to lambdas and logs
     Type: String
-    Default: !Ref "AWS::StackId"
+    Default: ""
 
 Conditions:
   ApplyPermissionsBoundary:
@@ -273,6 +273,7 @@ Conditions:
     - !Equals [!Ref CreateCloudFrontDistribution, "true"]
     - !Equals [!Ref CustomOriginDomainName, ""]
   UseWAF: !Not [!Equals [!Ref WebACLId, ""]]
+  UseResourceSuffix: !Not [!Equals [!Ref ResourceSuffix, ""]] # Use "" as default value for ResourceSuffix
   DefaultRootObjectProvided: !Not [!Equals [!Ref DefaultRootObject, ""]]
   CloudFrontAccessLogsBucketProvided:
     !Not [!Equals [!Ref CloudFrontAccessLogsBucket, ""]]
@@ -310,9 +311,12 @@ Resources:
   CheckAuthHandler:
     Type: AWS::Serverless::Function
     FunctionName:
-      Fn::Join:
-        - ""
-        - ["CheckAuthHandler", !Ref: "ResourceSuffix"]
+      !If
+        - UseResourceSuffix
+        - Fn::Join:
+            - ""
+            - ["CheckAuthHandler", !Ref: "ResourceSuffix"]
+        - AWS::NoValue
     Properties:
       CodeUri: src/lambda-edge/check-auth/
       Handler: bundle.handler
@@ -322,9 +326,12 @@ Resources:
   ParseAuthHandler:
     Type: AWS::Serverless::Function
     FunctionName:
-      Fn::Join:
-        - ""
-        - ["ParseAuthHandler", !Ref: "ResourceSuffix"]
+      !If
+        - UseResourceSuffix
+        - Fn::Join:
+            - ""
+            - ["ParseAuthHandler", !Ref: "ResourceSuffix"]
+        - AWS::NoValue
     Properties:
       CodeUri: src/lambda-edge/parse-auth/
       Handler: bundle.handler
@@ -334,9 +341,12 @@ Resources:
   RefreshAuthHandler:
     Type: AWS::Serverless::Function
     FunctionName:
-      Fn::Join:
-        - ""
-        - ["RefreshAuthHandler", !Ref: "ResourceSuffix"]
+     !If
+        - UseResourceSuffix
+        - Fn::Join:
+            - ""
+            - ["RefreshAuthHandler", !Ref: "ResourceSuffix"]
+        - AWS::NoValue
     Properties:
       CodeUri: src/lambda-edge/refresh-auth/
       Handler: bundle.handler
@@ -346,9 +356,12 @@ Resources:
   HttpHeadersHandler:
     Type: AWS::Serverless::Function
     FunctionName:
-      Fn::Join:
-        - ""
-        - ["HttpHeadersHandler", !Ref: "ResourceSuffix"]
+     !If
+        - UseResourceSuffix
+        - Fn::Join:
+            - ""
+            - ["HttpHeadersHandler", !Ref: "ResourceSuffix"]
+        - AWS::NoValue
     Properties:
       CodeUri: src/lambda-edge/http-headers/
       Handler: bundle.handler
@@ -358,9 +371,12 @@ Resources:
   SignOutHandler:
     Type: AWS::Serverless::Function
     FunctionName:
-      Fn::Join:
-        - ""
-        - ["SignOutHandler", !Ref: "ResourceSuffix"]
+     !If
+        - UseResourceSuffix
+        - Fn::Join:
+            - ""
+            - ["SignOutHandler", !Ref: "ResourceSuffix"]
+        - AWS::NoValue
     Properties:
       CodeUri: src/lambda-edge/sign-out/
       Handler: bundle.handler
@@ -370,9 +386,11 @@ Resources:
   TrailingSlashHandler:
     Type: AWS::Serverless::Function
     FunctionName:
-      Fn::Join:
-        - ""
-        - ["TrailingSlashHandler", !Ref: "ResourceSuffix"]
+     !If
+        - UseResourceSuffix
+        - Fn::Join:
+            - ""
+            - ["TrailingSlashHandler", !Ref: "ResourceSuffix"]
     Condition: RewritePathWithTrailingSlashToIndex
     Properties:
       CodeUri: src/lambda-edge/rewrite-trailing-slash/

--- a/template.yaml
+++ b/template.yaml
@@ -217,18 +217,6 @@ Parameters:
     Description: The lambda suffix to use, will be common to lambdas and logs
     Type: String
     Default: !Ref "AWS::StackId"
-  LogsDeletionPolicy:
-    Description: Retain Policy for logs when deleting stack
-    Type: String
-    Default: "Retain"
-    AllowedValues:
-      - "Delete"
-      - "Retain"
-      - "RetainExceptOnCreate"
-  LogsRetentionInDays:
-    Description: "Retention in days for logs"
-    Type: Integer
-    Default: 3653
 
 Conditions:
   ApplyPermissionsBoundary:
@@ -319,19 +307,8 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
 
-  CheckAuthHandlerLogGroup:
-    Type: AWS::Logs::LogGroup
-    DeletionPolicy: !Ref LogsDeletionPolicy
-    Properties:
-      LogGroupName:
-        Fn::Join:
-          - ""
-          - ["/aws/lambda/", "CheckAuthHandler", !Ref: "ResourceSuffix"]
-      RetentionInDays": !Ref LogsRetentionInDays
-
   CheckAuthHandler:
     Type: AWS::Serverless::Function
-    DependsOn: CheckAuthHandlerLogGroup
     FunctionName:
       Fn::Join:
         - ""
@@ -342,19 +319,8 @@ Resources:
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
-  ParseAuthHandlerLogGroup:
-    Type: AWS::Logs::LogGroup
-    DeletionPolicy: !Ref LogsDeletionPolicy
-    Properties:
-      LogGroupName:
-        Fn::Join:
-          - ""
-          - ["/aws/lambda/", "ParseAuthHandler", !Ref: "ResourceSuffix"]
-      RetentionInDays": !Ref LogsRetentionInDays
-
   ParseAuthHandler:
     Type: AWS::Serverless::Function
-    DependsOn: ParseAuthHandlerLogGroup
     FunctionName:
       Fn::Join:
         - ""
@@ -365,19 +331,8 @@ Resources:
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
-  RefreshAuthHandlerLogGroup:
-    Type: AWS::Logs::LogGroup
-    DeletionPolicy: !Ref LogsDeletionPolicy
-    Properties:
-      LogGroupName:
-        Fn::Join:
-          - ""
-          - ["/aws/lambda/", "RefreshAuthHandler", !Ref: "ResourceSuffix"]
-      RetentionInDays": !Ref LogsRetentionInDays
-
   RefreshAuthHandler:
     Type: AWS::Serverless::Function
-    DependsOn: RefreshAuthHandlerLogGroup
     FunctionName:
       Fn::Join:
         - ""
@@ -388,19 +343,8 @@ Resources:
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
-  HttpHeadersHandlerLogGroup:
-    Type: AWS::Logs::LogGroup
-    DeletionPolicy: !Ref LogsDeletionPolicy
-    Properties:
-      LogGroupName:
-        Fn::Join:
-          - ""
-          - ["/aws/lambda/", "HttpHeadersHandler", !Ref: "ResourceSuffix"]
-      RetentionInDays": !Ref LogsRetentionInDays
-
   HttpHeadersHandler:
     Type: AWS::Serverless::Function
-    DependsOn: HttpHeadersHandlerLogGroup
     FunctionName:
       Fn::Join:
         - ""
@@ -411,19 +355,8 @@ Resources:
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
-  SignOutHandlerLogGroup:
-    Type: AWS::Logs::LogGroup
-    DeletionPolicy: !Ref LogsDeletionPolicy
-    Properties:
-      LogGroupName:
-        Fn::Join:
-          - ""
-          - ["/aws/lambda/", "SignOutHandler", !Ref: "ResourceSuffix"]
-      RetentionInDays": !Ref LogsRetentionInDays
-
   SignOutHandler:
     Type: AWS::Serverless::Function
-    DependsOn: SignOutHandlerLogGroup
     FunctionName:
       Fn::Join:
         - ""
@@ -434,19 +367,8 @@ Resources:
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
-  TrailingSlashHandlerLogGroup:
-    Type: AWS::Logs::LogGroup
-    DeletionPolicy: !Ref LogsDeletionPolicy
-    Properties:
-      LogGroupName:
-        Fn::Join:
-          - ""
-          - ["/aws/lambda/", "TrailingSlashHandler", !Ref: "ResourceSuffix"]
-      RetentionInDays": !Ref LogsRetentionInDays
-
   TrailingSlashHandler:
     Type: AWS::Serverless::Function
-    DependsOn: TrailingSlashHandlerLogGroup
     FunctionName:
       Fn::Join:
         - ""

--- a/template.yaml
+++ b/template.yaml
@@ -213,6 +213,22 @@ Parameters:
     Description: The (pre-existing) Amazon S3 bucket to store CloudFront access logs in, for example, myawslogbucket.s3.amazonaws.com. Only of use if "CreateCloudFrontDistribution" is set to "true" (the default).
     Type: String
     Default: ""
+  ResourceSuffix:
+    Description: The lambda suffix to use, will be common to lambdas and logs
+    Type: String
+    Default: !Ref "AWS::StackId"
+  LogsDeletionPolicy:
+    Description: Retain Policy for logs when deleting stack
+    Type: String
+    Default: "Retain"
+    AllowedValues:
+      - "Delete"
+      - "Retain"
+      - "RetainExceptOnCreate"
+  LogsRetentionInDays:
+    Description: "Retention in days for logs"
+    Type: Integer
+    Default: 3653
 
 Conditions:
   ApplyPermissionsBoundary:
@@ -303,48 +319,138 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
 
+  CheckAuthHandlerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: !Ref LogsDeletionPolicy
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - ["/aws/lambda/", "CheckAuthHandler", !Ref: "ResourceSuffix"]
+      RetentionInDays": !Ref LogsRetentionInDays
+
   CheckAuthHandler:
     Type: AWS::Serverless::Function
+    DependsOn: CheckAuthHandlerLogGroup
+    FunctionName:
+      Fn::Join:
+        - ""
+        - ["CheckAuthHandler", !Ref: "ResourceSuffix"]
     Properties:
       CodeUri: src/lambda-edge/check-auth/
       Handler: bundle.handler
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
+  ParseAuthHandlerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: !Ref LogsDeletionPolicy
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - ["/aws/lambda/", "ParseAuthHandler", !Ref: "ResourceSuffix"]
+      RetentionInDays": !Ref LogsRetentionInDays
+
   ParseAuthHandler:
     Type: AWS::Serverless::Function
+    DependsOn: ParseAuthHandlerLogGroup
+    FunctionName:
+      Fn::Join:
+        - ""
+        - ["ParseAuthHandler", !Ref: "ResourceSuffix"]
     Properties:
       CodeUri: src/lambda-edge/parse-auth/
       Handler: bundle.handler
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
+  RefreshAuthHandlerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: !Ref LogsDeletionPolicy
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - ["/aws/lambda/", "RefreshAuthHandler", !Ref: "ResourceSuffix"]
+      RetentionInDays": !Ref LogsRetentionInDays
+
   RefreshAuthHandler:
     Type: AWS::Serverless::Function
+    DependsOn: RefreshAuthHandlerLogGroup
+    FunctionName:
+      Fn::Join:
+        - ""
+        - ["RefreshAuthHandler", !Ref: "ResourceSuffix"]
     Properties:
       CodeUri: src/lambda-edge/refresh-auth/
       Handler: bundle.handler
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
+  HttpHeadersHandlerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: !Ref LogsDeletionPolicy
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - ["/aws/lambda/", "HttpHeadersHandler", !Ref: "ResourceSuffix"]
+      RetentionInDays": !Ref LogsRetentionInDays
+
   HttpHeadersHandler:
     Type: AWS::Serverless::Function
+    DependsOn: HttpHeadersHandlerLogGroup
+    FunctionName:
+      Fn::Join:
+        - ""
+        - ["HttpHeadersHandler", !Ref: "ResourceSuffix"]
     Properties:
       CodeUri: src/lambda-edge/http-headers/
       Handler: bundle.handler
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
+  SignOutHandlerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: !Ref LogsDeletionPolicy
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - ["/aws/lambda/", "SignOutHandler", !Ref: "ResourceSuffix"]
+      RetentionInDays": !Ref LogsRetentionInDays
+
   SignOutHandler:
     Type: AWS::Serverless::Function
+    DependsOn: SignOutHandlerLogGroup
+    FunctionName:
+      Fn::Join:
+        - ""
+        - ["SignOutHandler", !Ref: "ResourceSuffix"]
     Properties:
       CodeUri: src/lambda-edge/sign-out/
       Handler: bundle.handler
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
+  TrailingSlashHandlerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: !Ref LogsDeletionPolicy
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - ["/aws/lambda/", "TrailingSlashHandler", !Ref: "ResourceSuffix"]
+      RetentionInDays": !Ref LogsRetentionInDays
+
   TrailingSlashHandler:
     Type: AWS::Serverless::Function
+    DependsOn: TrailingSlashHandlerLogGroup
+    FunctionName:
+      Fn::Join:
+        - ""
+        - ["TrailingSlashHandler", !Ref: "ResourceSuffix"]
     Condition: RewritePathWithTrailingSlashToIndex
     Properties:
       CodeUri: src/lambda-edge/rewrite-trailing-slash/


### PR DESCRIPTION
Logs and naming is currently problematic in CloudFront authorization@edge

 - lambdas are named with random IDs, making it difficult to identify easily the deployed lambdas
 - log groups are created without tags and offer no possibilies of setting their retention
 - logs are impossible to identify: each stack being deployed has random IDs, so not possible to correlate logs easily

As LogGroup sucks with CloudFormation, because LogGroup has to be created before the lambda which creates the log group if not present, this MR follows this strategy:

- Use a common ResourceSuffix (initialized with the StackId) => Possible not to use an ID but a name for user
- Re-Use the suffix for both LogGroupName and Lambda, so IDs are predictable and can be hardcoded for logs
- Use default log retention policy of 10 years to avoid bad suprises for existing users