### PR TITLE
fix: add PutBucketTagging to UsEast1DeploymentHandler policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -453,6 +453,7 @@ Resources:
                 - s3:DeleteBucket
                 - s3:DeleteObject
                 - s3:ListBucket
+                - s3:PutBucketTagging
               Resource: !Sub "arn:${AWS::Partition}:s3:::*-authedgedeploymentbucket-*"
             - Effect: Allow
               Action: lambda:GetFunction


### PR DESCRIPTION
_Issue #, if available:_ 260

_Description of changes:_

Add s3:PutBucketTagging to the allowed actions in UsEast1DeploymentHandler's policies. 

[x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.