### PR TITLE
Fix: handle expiration of refresh token

### DIFF
--- a/src/lambda-edge/http-headers/index.ts
+++ b/src/lambda-edge/http-headers/index.ts
@@ -11,6 +11,6 @@ export const handler: CloudFrontResponseHandler = async (event) => {
   CONFIG.logger.debug("Event:", event);
   const response = event.Records[0].cf.response;
   Object.assign(response.headers, CONFIG.cloudFrontHeaders);
-  CONFIG.logger.debug("Returning response:\n", response);
+  CONFIG.logger.debug("Returning response:\n", JSON.stringify(response));
   return response;
 };

--- a/src/lambda-edge/parse-auth/index.ts
+++ b/src/lambda-edge/parse-auth/index.ts
@@ -79,14 +79,6 @@ export const handler: CloudFrontRequestHandler = async (event) => {
         );
       });
     CONFIG.logger.info("Successfully exchanged authorization code for tokens");
-    CONFIG.logger.debug("Response from Cognito token endpoint:\n", {
-      status,
-      headers,
-      idToken,
-      accessToken,
-      refreshToken,
-    });
-
     const response = {
       status: "307",
       statusDescription: "Temporary Redirect",
@@ -108,7 +100,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
         ...CONFIG.cloudFrontHeaders,
       },
     };
-    CONFIG.logger.debug("Returning response:\n", response);
+    CONFIG.logger.debug("Returning response:\n", JSON.stringify(response));
     return response;
   } catch (err) {
     CONFIG.logger.error(err);
@@ -133,7 +125,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
           ...CONFIG.cloudFrontHeaders,
         },
       };
-      CONFIG.logger.debug("Returning response:\n", response);
+      CONFIG.logger.debug("Returning response:\n", JSON.stringify(response));
       return response;
     }
     let htmlParams: Parameters<typeof common.createErrorHtml>[0];
@@ -169,7 +161,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
         ],
       },
     };
-    CONFIG.logger.debug("Returning response:\n", response);
+    CONFIG.logger.debug("Returning response:\n", JSON.stringify(response));
     return response;
   }
 };

--- a/src/lambda-edge/sign-out/index.ts
+++ b/src/lambda-edge/sign-out/index.ts
@@ -20,13 +20,13 @@ export const handler: CloudFrontRequestHandler = async (event) => {
   CONFIG.logger.debug("Event:", event);
   const request = event.Records[0].cf.request;
   const domainName = request.headers["host"][0].value;
-  const { idToken, accessToken, refreshToken } = extractAndParseCookies(
+  const cookies = extractAndParseCookies(
     request.headers,
     CONFIG.clientId,
     CONFIG.cookieCompatibility
   );
 
-  if (!idToken) {
+  if (!cookies.idToken) {
     const response = {
       body: createErrorHtml({
         title: "Signed out",
@@ -45,7 +45,7 @@ export const handler: CloudFrontRequestHandler = async (event) => {
         ],
       },
     };
-    CONFIG.logger.debug("Returning response:\n", response);
+    CONFIG.logger.debug("Returning response:\n", JSON.stringify(response));
     return response;
   }
 
@@ -68,13 +68,13 @@ export const handler: CloudFrontRequestHandler = async (event) => {
       ],
       "set-cookie": generateCookieHeaders.signOut({
         tokens: {
-          id: idToken,
+          id: cookies.idToken,
         },
         ...CONFIG,
       }),
       ...CONFIG.cloudFrontHeaders,
     },
   };
-  CONFIG.logger.debug("Returning response:\n", response);
+  CONFIG.logger.debug("Returning response:\n", JSON.stringify(response));
   return response;
 };


### PR DESCRIPTION
_Issue #, if available:_ N/A

_Description of changes:_ When the ID and Access tokens have expired, and the Refresh token too, the user is now redirected to the Cognito Hosted UI to sign-in. Previously, this resulted in the [custom Auth@Edge error page](https://github.com/aws-samples/cloudfront-authorization-at-edge/blob/master/src/lambda-edge/shared/error-page/template.html) to be shown, which made the user explicitly click the sign-in button to be redirected to the Cognito Hosted UI to sign-in. That page should be shown for edge cases only.

Implemented as follows:
1. RefreshAuth function: if the refresh fails with invalid_grant message from Cognito, we assume the refresh token expired and clear the cookie
2. CheckAuth function: if the ID and Access token are expired and there is no refresh token (because it was now cleared), the user is redirected to Cognito for sign-in

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
