### PR TITLE
Fixing /refreshauth for static sites

### DIFF
--- a/src/lambda-edge/check-auth/index.ts
+++ b/src/lambda-edge/check-auth/index.ts
@@ -44,7 +44,10 @@ export const handler: CloudFrontRequestHandler = async (event) => {
     // If the JWT is expired we can try to refresh it
     // This is done by redirecting the user to the refresh path.
     // If the refresh works, the user will be redirected back here (this time with valid JWTs)
-    if (err instanceof common.JwtExpiredError && refreshToken) {
+    if (
+      err instanceof common.JwtExpiredError &&
+      (CONFIG.mode == "staticSiteMode" || refreshToken)
+    ) {
       CONFIG.logger.debug("Redirecting user to refresh path");
       return redirectToRefreshPath({ domainName, requestedUri });
     }


### PR DESCRIPTION
When protecting a static site (SPAMode: 'staticSiteMode') and using the default setting for (RedirectPathAuthRefresh: '/refreshauth'), the checkAuth handler does not properly handle expired access tokens. 

Expected Behavior:
1. transparently redirect the user to the refreshtoken URL
2. refresh the access token using the refresh token
3. transparently redirect the user back to the original page

Observed Beahvior:
1. The user is redirected to the user to the Cognito Hosted UI, prompting the user to login.

Analysis:
In the checkAuth handler, it does properly detect when the jwt is expired, but it is also checking to ensure that the user has a refresh token before redirecting to the refreshauth url. The default setting for static sites restricts the path of the refresh token's cookie to only send to the refreshauth url. This means that there will never be a refresh token on these requests, so the case always falls through to the default which is to send the user to the Cognito Hosted UI.

Solution:
Only require the refresh token to be present if the site is not in static site mode.