### PR TITLE
Fix refresh for static site scenario

### DIFF
--- a/src/lambda-edge/shared/shared.ts
+++ b/src/lambda-edge/shared/shared.ts
@@ -340,6 +340,7 @@ export function extractAndParseCookies(
     nonce: cookies["spa-auth-edge-nonce"],
     nonceHmac: cookies["spa-auth-edge-nonce-hmac"],
     pkce: cookies["spa-auth-edge-pkce"],
+    refreshFailed: cookies["spa-auth-edge-refresh"],
   };
 }
 
@@ -443,6 +444,10 @@ function _generateCookieHeaders(
       cookiesToSetOrExpire[
         cookieNames.cognitoEnabledKey
       ] = `True; ${param.cookieSettings.cognitoEnabled}`;
+    // Clear marker for failed refresh
+    cookiesToSetOrExpire["spa-auth-edge-refresh"] = addExpiry(
+      param.cookieSettings.nonce
+    );
   } else if (param.scenario === "REFRESH") {
     cookiesToSetOrExpire[
       cookieNames.idTokenKey
@@ -450,6 +455,10 @@ function _generateCookieHeaders(
     cookiesToSetOrExpire[
       cookieNames.accessTokenKey
     ] = `${param.tokens.access}; ${param.cookieSettings.accessToken}`;
+    // Clear marker for failed refresh
+    cookiesToSetOrExpire["spa-auth-edge-refresh"] = addExpiry(
+      param.cookieSettings.nonce
+    );
   } else if (param.scenario === "SIGN_OUT") {
     // Expire JWTs
     cookiesToSetOrExpire[cookieNames.idTokenKey] = addExpiry(
@@ -482,11 +491,19 @@ function _generateCookieHeaders(
       cookiesToSetOrExpire[cookieNames.cognitoEnabledKey] = addExpiry(
         param.cookieSettings.cognitoEnabled
       );
+    // Clear marker for failed refresh
+    cookiesToSetOrExpire["spa-auth-edge-refresh"] = addExpiry(
+      param.cookieSettings.nonce
+    );
   } else if (param.scenario === "REFRESH_FAILED") {
     // Expire refresh token only
     cookiesToSetOrExpire[cookieNames.refreshTokenKey] = addExpiry(
       param.cookieSettings.refreshToken
     );
+    // Add marker for failed refresh
+    cookiesToSetOrExpire[
+      "spa-auth-edge-refresh"
+    ] = `failed; ${param.cookieSettings.nonce}`;
   }
 
   // Always expire nonce, nonceHmac and pkce

--- a/template.yaml
+++ b/template.yaml
@@ -808,6 +808,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt StaticSiteHandler.Arn
       BucketName: !Ref S3Bucket
+      Version: !Ref Version
 
   StaticSiteHandler:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
_Issue #, if available:_ #285

_Description of changes:_ Changed the way refresh works so that it also works in static site and other scenario's where checkauth handler cannot "see" the refresh token cookie--if it was limited to be sent to the refresh path only. Instead we now try the refresh always. To prevent an infinite loop in case refresh would fail, we rely on the presence of a marker cookie.

Success scenario:

1. at requested path: check JWT, if JWT expired --> redirect to refresh path
2. at refresh path: attempt refresh --> OK --> set new JWTs in cookies, redirect back to requested path
3. at requested path: check JWT, now OK

Refresh fails scenario:

1. at requested path: check JWT, if JWT expired --> redirect to refresh path
2. at refresh path: attempt refresh --> Failure --> set marker cookie "refresh failed", redirect back to requested path
3. at requested path: check JWT, still expired, but marker cookie "refresh failed" present, so --> redirect to Cognito Hosted UI for sign in

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
