### PR TITLE
Update template.yaml

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -653,6 +653,7 @@ Resources:
   UserPoolGroupAttachment:
     Type: AWS::Cognito::UserPoolUserToGroupAttachment
     Condition: AttachUserToPoolGroup
+    DependsOn: User
     Properties:
       GroupName: !Ref UserPoolGroupName
       Username: !Ref EmailAddress


### PR DESCRIPTION
Added depends on condition for the UserPoolGroupAttachment to avoid the template failing.

_Issue #, if available: None

_Description of changes: Added the depends on condition because there is an issue where the user is not done creating and then it fails with the message: 

Resource handler returned message: "User does not exist. (Service: CognitoIdentityProvider, Status Code: 400, Request ID: ######)" (RequestToken: #####, HandlerErrorCode: NotFound)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
